### PR TITLE
UTF-8 Encoding htmlentities

### DIFF
--- a/src/SynergyDataGrid/Grid/Column.php
+++ b/src/SynergyDataGrid/Grid/Column.php
@@ -247,7 +247,7 @@
             } elseif (is_array($cellValue)) {
                 $retv = serialize($cellValue);
             } else {
-                $retv = htmlentities($cellValue);
+                $retv = htmlentities($cellValue, ENT_QUOTES, "UTF-8");
             }
 
             return $retv;


### PR DESCRIPTION
Default value for htmlentities encoding is ISO-8859-1 in versions of PHP prior to 5.4.0. This will break json_encode, if you use UTF-8 characters.
