### PR TITLE
Remove view stack since it's unnessessary.

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -12,12 +12,6 @@
      *
      */
     return array(
-        'view_manager' => array(
-            'template_path_stack' => array(
-                __DIR__ . '/../view',
-            ),
-        ),
-
         'jqgrid'       => array(
             /**
              * settings for customising plugins e.g. jquery datepicker


### PR DESCRIPTION
Alternative view rendere's may throw exceptions since the view folder does not exist.

Example for ZfcTwig:

`Fatal error: Uncaught exception 'Twig_Error_Loader' with message 'The  /var/www/project/vendor/synergy/synergydatagrid/config/../view/" directory does not exist.' in /var/www/project/vendor/zendframework/zendframework/library/Zend/ServiceManager/ServiceManager.php on line 859`

To avoid this you should strip this you should strip this unneeded entry in the configuration.
